### PR TITLE
fix php-sapi.postrm syntax error

### DIFF
--- a/debian/php-sapi.postrm
+++ b/debian/php-sapi.postrm
@@ -44,7 +44,7 @@ if [ "$1" = "purge" ]; then
     for dir in \
 	/etc/php/@PHP_VERSION@/@sapi@/conf.d \
 	/etc/php/@PHP_VERSION@/@sapi@ \
-	/etc/php/@PHP_VERSION@/
+	/etc/php/@PHP_VERSION@/ \
 	/etc/php; do
 	
 	if [ -d $dir ]; then


### PR DESCRIPTION
missing backslash in for loop

for:
```
The following packages will be REMOVED:
  php7.0-cli php7.0-fpm
0 upgraded, 0 newly installed, 2 to remove and 0 not upgraded.
2 not fully installed or removed.
After this operation, 9,655 kB disk space will be freed.
Do you want to continue [Y/n]? y
(Reading database ... 210695 files and directories currently installed.)
Removing php7.0-fpm ...
/var/lib/dpkg/info/php7.0-fpm.postrm: 48: /var/lib/dpkg/info/php7.0-fpm.postrm: Syntax error: word unexpected (expecting "do")
dpkg: error processing php7.0-fpm (--remove):
 subprocess installed post-removal script returned error exit status 2
Removing php7.0-cli ...
/var/lib/dpkg/info/php7.0-cli.postrm: 47: /var/lib/dpkg/info/php7.0-cli.postrm: Syntax error: word unexpected (expecting "do")
dpkg: error processing php7.0-cli (--remove):
 subprocess installed post-removal script returned error exit status 2
Processing triggers for ureadahead ...
Errors were encountered while processing:
 php7.0-fpm
 php7.0-cli
E: Sub-process /usr/bin/dpkg returned an error code (1)
```