### PR TITLE
kill php7.0-fpm master proc more violently

### DIFF
--- a/debian/php-fpm.upstart
+++ b/debian/php-fpm.upstart
@@ -8,7 +8,7 @@ respawn
 respawn limit unlimited
 
 pre-start script
-	/bin/fuser --kill 9000/tcp --verbose || /bin/true
+	/bin/fuser -9 --kill 9000/tcp --verbose || /bin/true
 end script
 
 exec /usr/sbin/php-fpm7.0 --nodaemonize --fpm-config /etc/php/7.0/fpm/php-fpm.conf


### PR DESCRIPTION
there can be no lingering master processes after a restart
