### PR TITLE
remove adjust tidy extension for tidy html

### DIFF
--- a/debian/patches/series
+++ b/debian/patches/series
@@ -44,5 +44,4 @@
 0044-XMLRPC-EPI-library-has-to-be-linked-as-lxmlrpc-epi.patch
 0045-Really-expand-libdir-datadir-into-EXPANDED_LIBDIR-DA.patch
 0046-Fix-ext-date-lib-parse_tz-PATH_MAX-HURD-FTBFS.patch
-0047-Adjust-tidy-extension-for-tidy-html5.patch
 0048-Merge-OpenSSL-1.1.0-support-from-PHP-7.1-branch.patch


### PR DESCRIPTION
See https://github.com/pkg-php/php/issues/3

fixes:
```
libtool: compile:  x86_64-linux-gnu-gcc -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1 -Iext/tidy/ -I/tmp/buildd/php7.0-7.0.12/ext/tidy/ -DPHP_ATOM_INC -I/tmp/buildd/php7.0-7.0.12/ext-build/include -I/tmp/buildd/php7.0-7.0.12/ext-build/main -I/tmp/buildd/php7.0-7.0.12 -I/tmp/buildd/php7.0-7.0.12/ext-build/ext/date/lib -I/tmp/buildd/php7.0-7.0.12/ext/date/lib -I/usr/include/libxml2 -I/usr/include/enchant -I/usr/X11 -I/usr/include/freetype2 -I/usr/include/x86_64-linux-gnu -I/usr/include/c-client -I/tmp/buildd/php7.0-7.0.12/ext/mbstring/oniguruma -I/tmp/buildd/php7.0-7.0.12/ext-build/ext/mbstring/oniguruma -I/tmp/buildd/php7.0-7.0.12/ext/mbstring/libmbfl -I/tmp/buildd/php7.0-7.0.12/ext-build/ext/mbstring/libmbfl -I/tmp/buildd/php7.0-7.0.12/ext/mbstring/libmbfl/mbfl -I/tmp/buildd/php7.0-7.0.12/ext-build/ext/mbstring/libmbfl/mbfl -I/usr/include/postgresql -I/usr/include/pspell -I/usr/include/tidy -I/usr/include/xmlrpc-epi -I/tmp/buildd/php7.0-7.0.12/ext/zip/lib -I/tmp/buildd/php7.0-7.0.12/ext-build/TSRM -I/tmp/buildd/php7.0-7.0.12/ext-build/Zend -I/tmp/buildd/php7.0-7.0.12/main -I/tmp/buildd/php7.0-7.0.12/Zend -I/tmp/buildd/php7.0-7.0.12/TSRM -I/tmp/buildd/php7.0-7.0.12/ext-build/ -D_FORTIFY_SOURCE=2 -I/usr/include -g -O2 -fstack-protector --param=ssp-buffer-size=4 -Wformat -Wformat-security -Werror=format-security -O2 -Wall -pedantic -fsigned-char -fno-strict-aliasing -g -c /tmp/buildd/php7.0-7.0.12/ext/tidy/tidy.c  -fPIC -DPIC -o ext/tidy/.libs/tidy.o
In file included from /tmp/buildd/php7.0-7.0.12/Zend/zend.h:31:0,
                 from /tmp/buildd/php7.0-7.0.12/main/php.h:36,
                 from /tmp/buildd/php7.0-7.0.12/ext/tidy/tidy.c:25:
/tmp/buildd/php7.0-7.0.12/Zend/zend_types.h:51:15: warning: comma at end of enumerator list [-pedantic]
In file included from /tmp/buildd/php7.0-7.0.12/Zend/zend.h:37:0,
                 from /tmp/buildd/php7.0-7.0.12/main/php.h:36,
                 from /tmp/buildd/php7.0-7.0.12/ext/tidy/tidy.c:25:
/tmp/buildd/php7.0-7.0.12/Zend/zend_ast.h:148:18: warning: comma at end of enumerator list [-pedantic]
In file included from /tmp/buildd/php7.0-7.0.12/main/php.h:240:0,
                 from /tmp/buildd/php7.0-7.0.12/ext/tidy/tidy.c:25:
/tmp/buildd/php7.0-7.0.12/main/snprintf.h:153:9: warning: ISO C90 does not support 'long long' [-Wlong-long]
/tmp/buildd/php7.0-7.0.12/main/snprintf.h:154:18: warning: ISO C90 does not support 'long long' [-Wlong-long]
/tmp/buildd/php7.0-7.0.12/ext/tidy/tidy.c:34:24: fatal error: tidybuffio.h: No such file or directory
compilation terminated.
make[2]: *** [ext/tidy/tidy.lo] Error 1
```